### PR TITLE
Revise Lab 0.1 for Copilot Studio Licensing and PAYG

### DIFF
--- a/labs/0.1-enable-payg/0.1-enable-payg.md
+++ b/labs/0.1-enable-payg/0.1-enable-payg.md
@@ -1,117 +1,277 @@
-# Lab 0.1: Enable Pay-as-you-go for Copilot Studio
+# Lab 0.1: Understanding Copilot Studio Licensing and Enabling Pay-as-you-go Billing
 
 ## Objectives
 
-- Exercise: Enable Pay as you go for Copilot Studio in your tenant
-    - Task 1: Understand Copilot Studio licensing options
-    - Task 2: Create a billing plan for pay-as-you-go (if none is available already)
-
+- Exercise 1: Understand Copilot Studio licensing options
+    - Task 1: Core concept: Copilot Credits
+    - Task 2: Licensing and purchase models (PAYG, P1, P3 Agent Factory)
+    - Task 3: Included use rights with Microsoft 365 Copilot
+    - Task 4: Choosing the right model for your scenario
+- Exercise 2: Enable Pay-as-you-go billing
+    - Task 1: Create a billing plan in Power Platform Admin Center
+- Exercise 3: Acquire a Copilot Studio standalone license (P1)
+    - Task 1: Purchase and assign licenses in Microsoft 365 Admin Center
+- Exercise 4: Purchase a Microsoft Agent Pre-Purchase Plan (P3)
+    - Task 1: Buy Agent Credit Commit Units in Azure Portal
 
 ## Contents
 
-In this lab, you will learn about Copilot Studio licensing options and configure your tenant to use Pay-as-you-go, a flexible way to pay for Copilot Studio using an Azure subscription. This allows you to get started building agents without any license commitment or upfront purchasing. With the pay-as-you-go meter, at the end of each month, your organization pays only for the actual number of Copilot Credits its agents use during the month.
+In this lab, you will learn about the full spectrum of Copilot Studio licensing options: from pay-as-you-go flexibility to committed capacity packs (P1) and the unified Microsoft Agent Pre-Purchase Plan (P3 Agent Factory). You will also configure your tenant to use the model that best fits your scenario.
+
+Understanding these licensing models is essential for solution architects, IT admins, and fusion teams planning enterprise agent deployments: choosing the right model impacts cost predictability, capacity enforcement, and which Azure or Microsoft 365 services your agents can leverage.
 
 ## Prerequisites
 
 It's required to have completed **[Lab 0.0 - Create an agent](../0.0-create-an-agent/0.0-create-an-agent.md)** to follow this part.
 
-In order to set up pay-as-you-go billing for an environment, you first need
+Depending on which exercises you complete, you will need:
 
-  * An active Azure subscription that you can link to that environment. A resource group within this subscription. 
+| Exercise | Required roles |
+|----------|---------------|
+| Exercise 2 (PAYG) | Azure `Owner` or `Contributor` on Subscription and Resource Group **+** Power Platform `Environment admin`, `Power Platform admin`, `Global admin`, or `Dynamics 365 admin` |
+| Exercise 3 (P1) | Microsoft 365 `Global admin` or `Billing admin` |
+| Exercise 4 (P3) | Azure Subscription `Owner` or `Reservation purchaser` role |
 
-  * The user following this procedure requires `Owner` or `Contributor` role in Azure, both at the Subscription and the resource group.
-
-  * The user following this procedure requires **one** of the following roles in the Power Platform Admin Center: `Environment admin`, `Power Platform admin`, `Global admin`, `Dynamics 365 admin`.
- 
-  * Validate the most updated pre-requisites [here](https://learn.microsoft.com/en-us/power-platform/admin/pay-as-you-go-set-up).
-
+* Validate the most updated pre-requisites for [Pay-as-you-go](https://learn.microsoft.com/en-us/power-platform/admin/pay-as-you-go-set-up), [Copilot Studio licensing](https://learn.microsoft.com/en-us/microsoft-copilot-studio/requirements-licensing), and the [Microsoft Agent Pre-Purchase Plan](https://learn.microsoft.com/en-us/azure/cost-management-billing/reservations/agent-pre-purchase).
 
 ## Estimated Completion Time
 
-- 30 minutes
+- 45 minutes
 
+---
 
-## Exercise 1: Link your environment to an Azure Subscription (Pay-as-you-go)
+## Exercise 1: Understanding Copilot Studio Licensing
+
+### Task 1: Core licensing concept: Copilot Credits
+
+Copilot Studio consumption is measured using **Copilot Credits**, which represent the compute and effort required for an agent to:
+- Retrieve information from knowledge sources
+- Generate responses using LLMs
+- Execute actions (workflows, AI tools, custom skills, connectors)
+
+Copilot Credits act as a **common currency** across all Copilot Studio capabilities. The number of credits consumed per interaction depends on task complexity: a simple FAQ answer consumes fewer credits than a multi-step orchestration that calls external APIs, runs Power Automate flows, and generates a grounded response from multiple knowledge bases.
+
+> **Important:** Starting on September 1, 2025, the common currency for agents changed from *messages* to *Copilot Credits*. There is no change in the quantity per prepaid pack or to the pay-as-you-go rate.
+
+#### How credits are consumed
+
+| Agent action | Credit impact |
+|-------------|--------------|
+| Classic answer (pre-authored topic) | Lower |
+| Generative answer (single knowledge source) | Medium |
+| Generative orchestration (multiple sources + actions) | Higher |
+| Tool/Skill invocation (API calls, connectors) | Varies by complexity |
+| Power Automate cloud flow execution | Additional credits |
+
+> **Tip:** Use the [Microsoft Copilot Studio agent usage estimator](https://microsoft.github.io/copilot-studio-estimator/) to forecast your agent's Copilot Credit volume before choosing a purchase model.
+
+---
+
+### Task 2: Licensing and purchase models
+
+Copilot Studio offers four ways to acquire Copilot Credits. Each model targets a different organizational profile in terms of commitment, cost predictability, and scope.
+
+#### 2.1 Pay-As-You-Go (PAYG) Meter
+
+Designed for **flexibility, variable workloads, and getting started quickly**.
+
+| Aspect | Detail |
+|--------|--------|
+| **Billing model** | Per credit consumed each month, billed to an Azure subscription. No upfront commitment. |
+| **Credit allocation** | None: you pay only for what you use |
+| **Overages** | No service interruption: usage is metered continuously |
+| **Administration** | Requires the Copilot Studio Author (Environment Maker) role to build/manage agents. The Author role itself has no license cost. Access is controlled via the "Copilot Authors" tenant setting in Power Platform Admin Center (PPAC). |
+| **Billing scope** | Configured per environment via a billing policy linking a Power Platform environment to an Azure subscription + resource group |
+| **Best for** | Development, testing, proof-of-concepts, seasonal spikes, unpredictable usage patterns |
+
+**Key advantages:**
+- Zero barrier to entry: start building agents immediately without procurement cycles
+- Full cost visibility through Azure Cost Management, tags, and budgets
+- Can serve as a safety net for other models: if capacity packs (P1) are exhausted, PAYG absorbs overages
+
+---
+
+#### 2.2 Copilot Studio Standalone License: Copilot Credit Capacity Pack (P1)
+
+Aimed at **predictable, steady production workloads** with committed monthly capacity.
+
+| Aspect | Detail |
+|--------|--------|
+| **Billing model** | Monthly subscription purchased per tenant through Microsoft 365 Admin Center or Volume Licensing |
+| **Credit allocation** | 25,000 Copilot Credits per pack per month. Multiple packs can be purchased to increase capacity. |
+| **Credit rollover** | Credits do **not** roll over month-to-month |
+| **Overages** | By default, agents stop responding when capacity is exhausted. PAYG can be configured as a safety net: PAYG is only billed after capacity packs are fully consumed. |
+| **Administration** | Requires two licenses in M365 Admin Center: (1) *Copilot Studio* tenant license and (2) *Copilot Studio User License* per author. The User License has no cost. |
+| **Billing scope** | Capacity can be allocated and monitored by environment and by agent in PPAC |
+| **Best for** | Production deployments with consistent usage, organizations wanting predictable monthly costs, environments where Azure billing is not available |
+
+**Key advantages:**
+- Predictable monthly cost: fixed capacity per pack regardless of actual consumption
+- Granular capacity allocation: assign credits to specific environments or individual agents
+- No Azure subscription required: purchasing and management happen entirely in the Microsoft 365 Admin Center
+- Overage protection: combine with PAYG to prevent service disruption when packs are exhausted
+
+**License components explained:**
+
+| License name (M365 Admin Center) | Type | Cost | Purpose |
+|----------------------------------|------|------|---------|
+| Copilot Studio | Tenant license | Paid (includes 25K credits/month) | Enables Copilot Studio for the organization |
+| Copilot Studio User License | Per-user license | Free | Grants individual users access to create and manage agents |
+
+> **Important:** If you purchase Copilot Studio through volume licensing or any channel other than the Microsoft 365 Admin Center, you must acquire both the tenant license and user licenses through that same channel, preferably as part of a single transaction.
+
+---
+
+#### 2.3 Copilot Credits Pre-Purchase Plan
+
+Optimized for organizations **committing to higher annual usage** with cost predictability and volume discounts.
+
+| Aspect | Detail |
+|--------|--------|
+| **Billing model** | One-year prepaid commitment purchased in Azure Portal. Uses Copilot Credit Commit Units (CCCUs): 1 CCCU = 100 Copilot Credits. |
+| **Credit allocation** | Pool of CCCUs usable across eligible Microsoft products over the one-year term |
+| **Credit expiry** | Unused credits expire after the one-year term |
+| **Overages** | Same as Copilot Credit Capacity Packs: PAYG can absorb overages |
+| **Administration** | Same as Copilot Credit Capacity Packs (requires M365 tenant + user licenses). Also requires a billing policy in PPAC linking to the Azure subscription. |
+| **Billing scope** | Same as Copilot Credit Capacity Packs |
+| **Best for** | Organizations with committed annual budgets, enterprises that prefer CapEx-style purchasing, scenarios requiring volume discounts |
+
+---
+
+#### 2.4 Microsoft Agent Pre-Purchase Plan (P3 Agent Factory)
+
+The **unified purchasing construct** that spans Microsoft Foundry and all Copilot Credits-enabled agentic services under a single budget.
+
+| Aspect | Detail |
+|--------|--------|
+| **Billing model** | One-year prepaid commitment via Agent Credit Commit Units (ACUs) purchased in Azure Portal under Reservations. 1 ACU pays for $1 USD of eligible retail usage. Tiered pricing: the more you buy, the greater the discount. |
+| **Services covered** | **32+ services** across the Microsoft AI stack: Azure AI Search, Azure OpenAI (PTU and token-based), Azure AI Services (Speech, Vision, Language, Content Safety, etc.), Microsoft Copilot Studio, Dynamics 365 first-party agents, Microsoft Fabric, GitHub, and more |
+| **Credit expiry** | Unused ACUs expire after the one-year term. Plans auto-renew by default. |
+| **Overages** | Usage exceeding ACU balance is billed at pay-as-you-go rates |
+| **Administration** | Purchased and managed via [Azure Portal Reservations](https://learn.microsoft.com/en-us/azure/cost-management-billing/reservations/agent-pre-purchase). Requires Azure Subscription Owner or Reservation Purchaser role. |
+| **Billing scope** | Can be scoped to a single resource group, single subscription, shared across all subscriptions in a billing context, or a management group |
+| **Best for** | Organizations building agents that span both Copilot Studio and Azure AI Foundry, enterprises wanting a single budget for their entire AI portfolio, scenarios requiring cross-platform cost optimization |
+
+**Key advantages:**
+- **Unified budget**: one plan covers both Copilot Studio credits and Azure AI Foundry consumption: no separate budgets to manage
+- **Broad service coverage**: 32+ services included, eliminating the need for separate reservations per service
+- **Volume discounts**: tiered pricing rewards larger commitments
+- **Flexibility across platforms**: the same ACUs pay for Copilot Studio agent interactions, Azure OpenAI model calls, AI Search queries, and more
+- **Automatic benefit application**: ACUs are consumed automatically without redeployment or reassignment
+
+**Benefit application order (when multiple plans coexist):**
+
+When an organization holds multiple purchasing plans, Microsoft applies benefits in this precedence order to maximize savings:
+
+| Priority | Plan | Covers |
+|----------|------|--------|
+| 1st | Microsoft Foundry PTU Reservations | PTU usage (most cost-effective for provisioned throughput) |
+| 2nd | Copilot Credit Pre-Purchase Plan | Copilot-specific workloads |
+| 3rd | Microsoft Agent Pre-Purchase Plan (P3) | Remaining AI usage across all platforms |
+
+> **Note:** The Microsoft Agent Pre-Purchase Plan does not cover the purchase cost of other reservations or prepurchase plans: only actual usage costs.
+
+**Example calculation:**
+
+Consider a scenario where your organization plans to use:
+- **Copilot Credits**: 1,500,000 credits for custom agents in Copilot Studio
+- **Microsoft Foundry PTUs**: 5,000 PTU hours for AI model deployments
+
+| | Pay-as-you-go | P3 Agent Factory (Tier 1) |
+|--|---------------|---------------------------|
+| Copilot Credit cost | $15,000 | Covered by ACUs |
+| PTU usage cost | $5,000 | Covered by ACUs |
+| **Total** | **$20,000** | **~$19,000 (≈5% savings)** |
+
+Savings increase with higher tiers and larger commitments.
+
+---
+
+### Task 3: Included use rights with Microsoft 365 Copilot
+
+Organizations with **Microsoft 365 Copilot** licenses get limited Copilot Studio use rights at no additional cost:
+
+| Capability | Included? | Notes |
+|-----------|-----------|-------|
+| Build agents in Copilot Studio | ✅ | For employee-facing scenarios only |
+| Publish to Teams, SharePoint, M365 Copilot | ✅ | Agents operate under the licensed user's identity |
+| Classic answers in M365 Copilot | ✅ | Zero-rated usage (no credit consumption) |
+| Generative answers in M365 Copilot | ✅ | Zero-rated usage (no credit consumption) |
+| Microsoft Graph tenant grounding | ✅ | Zero-rated usage (no credit consumption) |
+| External channels (web, custom) | ❌ | Requires standalone Copilot Studio license or PAYG |
+| Premium connectors beyond M365 | ❌ | Requires standalone Copilot Studio license or PAYG |
+
+> **Key takeaway:** If your agents are exclusively employee-facing and deployed within the Microsoft 365 ecosystem (Teams, SharePoint, Copilot Chat), M365 Copilot licenses may already cover your needs. For external-facing agents or scenarios requiring premium connectors, a separate Copilot Studio licensing model is required.
+
+---
+
+### Task 4: Choosing the right model for your scenario
+
+Use this decision guide to select the licensing model that best fits your needs:
+
+```
+                         ┌─────────────────────────┐
+                         │ Do you need agents only  │
+                         │ within Microsoft 365?    │
+                         └──────────┬──────────────┘
+                                    │
+                          ┌─────Yes─┴──No──────┐
+                          ▼                     ▼
+                ┌─────────────────┐   ┌──────────────────────┐
+                │ M365 Copilot    │   │ Is your usage         │
+                │ included rights │   │ predictable?          │
+                │ may suffice     │   └──────────┬───────────┘
+                └─────────────────┘              │
+                                       ┌──Yes───┴───No───┐
+                                       ▼                  ▼
+                              ┌────────────────┐  ┌──────────────┐
+                              │ Do you also use │  │ Pay-As-You-Go│
+                              │ Azure AI        │  │ (PAYG)       │
+                              │ Foundry?        │  └──────────────┘
+                              └───────┬────────┘
+                                      │
+                            ┌──Yes────┴───No────┐
+                            ▼                    ▼
+                   ┌─────────────────┐  ┌────────────────────┐
+                   │ P3 Agent Factory│  │ P1 Capacity Pack   │
+                   │ (unified plan)  │  │ or Pre-Purchase    │
+                   └─────────────────┘  └────────────────────┘
+```
+
+#### Quick comparison summary
+
+| Criterion | PAYG | P1 (Capacity Pack) | Pre-Purchase | P3 Agent Factory |
+|-----------|------|---------------------|-------------|------------------|
+| **Commitment** | None | Monthly | Annual | Annual |
+| **Payment** | Per credit consumed | Fixed monthly | Prepaid annual | Prepaid annual |
+| **Credits included** | None (metered) | 25,000/pack/month | Pool of CCCUs | Pool of ACUs |
+| **Azure AI Foundry coverage** | ❌ | ❌ | ❌ | ✅ (32+ services) |
+| **Volume discounts** | ❌ | ❌ | ✅ | ✅ (tiered) |
+| **Requires Azure subscription** | ✅ | ❌ | ✅ | ✅ |
+| **Best for** | Dev/test, POCs | Steady production | Annual budgets | Multi-platform AI |
+
+> **Note:**
+> - **Authoring vs. Consumption**: Author roles/licenses have no cost. Actual cost is driven entirely by Copilot Credit consumption.
+> - **Capacity Enforcement**: All purchased capacity is enforced monthly. Unused monthly credits do not carry over. Sustained overuse can result in technical enforcement including service denial.
+> - **Mixing models**: Organizations can combine models. For example, use P1 capacity packs for predictable production workloads and PAYG as a safety net for overages or dev/test environments.
+> - For the most current licensing information, pricing, and detailed feature comparisons, refer to the official [Microsoft Copilot Studio licensing documentation](https://learn.microsoft.com/en-us/microsoft-copilot-studio/requirements-licensing).
+
+---
+
+## Exercise 2: Enable Pay-as-you-go Billing
 
 In the Power Platform admin center, you can link environments to an Azure subscription using a billing policy. Linking an environment to an Azure subscription turns on billing through Azure meters. Any app usage or Dataverse and Power Platform usage that exceeds the included amounts is billed to the Azure subscription.
 
-> **When to use Pay-as-you-go**: This approach is ideal for development, testing, proof-of-concepts, or scenarios with unpredictable usage patterns. For production deployments with consistent usage, consider Copilot Credits Capacity Packs which may be more cost-effective.
+> **When to use Pay-as-you-go**: This approach is ideal for development, testing, proof-of-concepts, or scenarios with unpredictable usage patterns. For production deployments with consistent usage, consider Copilot Credit Capacity Packs (P1) which may be more cost-effective.
 
-### Task 1: Understanding Copilot Studio Licensing
+### Prerequisites for this exercise
 
-#### 1. Core licensing concept: Copilot credits
-Copilot Studio consumption is measured using Copilot Credits, which represent the compute and effort required for an agent to:
-- Retrieve information
-- Generate responses
-- Execute actions (workflows, AI tools, custom skills)
+* An active Azure subscription that you can link to an environment. A resource group within this subscription.
+* The user following this procedure requires `Owner` or `Contributor` role in Azure, both at the Subscription and the resource group.
+* The user following this procedure requires **one** of the following roles in the Power Platform Admin Center: `Environment admin`, `Power Platform admin`, `Global admin`, `Dynamics 365 admin`.
+* Validate the most updated pre-requisites [here](https://learn.microsoft.com/en-us/power-platform/admin/pay-as-you-go-set-up).
 
-Copilot Credits act as a **common currency** across all Copilot Studio capabilities, and the number of credits consumed depends on task complexity.
-
-#### 2. Three Consumption & Purchase models
-#### 2.1 Pay-As-You-Go (PAYG) Meter
-
-Designed for flexibility, variable workloads, and seasonal scenarios.
-
-- Billing model: Organizations pay per number of credit consumed each month via Azure. No upfront commitment.
-- Consumption overages: No service interruption due to credit overages
-- Administration:
-  - Requires Copilot Studio Author (Environment Maker) role to build/manage agents
-  - Author role itself has no license cost
-  - Copilot Studio access: Needs updating "Copilot Authors" tenant setting in Power Platform Admin Center (PPAC).
-- Billing scope: Configured per environment via a billing plan
-
-#### 2.2 Copilot Studio License (Copilot Credit Capacity Pack)
-
-Aimed at predictable, steady Copilot usage.
-
-- Billing Model: Monthly subscription (per tenant). Included capacity is 25,000 Copilot Credits per pack per month. Credits do not roll over month‑to‑month
-- Consumption overages:
-  - PAYG can be configured as a safety net
-  - PAYG then is only billed after capacity packs are exhausted
-- Administration:
-  - Requires Copilot Studio User License per author and Copilot Studio Author (Environment Maker) role to build/manage agents
-  - Copilot Studio User License has no cost
-- Billing scope: Can be configured by environment and agent.
-
-#### 2.3 Copilot Credits Pre‑Purchase Plan
-
-Optimized for organizations committing to higher annual usage with cost predictability.
-
-- Billing Model: One-year, prepaid commitment via Copilot Credit Commit Units (CCCUs). 1 CCCU is equivalent to 100 Copilot Credits. Credits expire after one year.
-- Consumption overages: Same as Copilot Credit Capacity packs.
-- Administration: Same as Copilot Credit Capacity packs.
-- Billing scope: Same as Copilot Credit Capacity packs.
-
-
-#### 2.4 Microsoft Agent Pre-Purchase Plan (P3) Plan
-
-Unified purchasing construct that spans Microsoft Foundry and Copilot Credits* enabled agentic services.
-
-- Billing Model: One-year, prepaid commitment via. Use the same budget across both Azure AI Foundry and Copilot Studio.
-- 32 services included: Tap into Azure AI Search, Cognitive Services, Direct Models, Copilot Studio, and more—all under one plan.
-- Administration: [Reservations](https://learn.microsoft.com/en-us/azure/cost-management-billing/reservations/agent-pre-purchase)in Azure Portal. 
-
-#### 3. Includes Use rights with Microsoft 365 Copilot
-
-- Microsoft 365 Copilot User Subscription License (USL) includes limited Copilot Studio use rights
-- Usage is restricted to employee‑facing scenarios and bound by a fair‑usage limit
-- Agents built for Teams, SharePoint, or Microsoft 365 Copilot are included when operating under the licensed user’s identity
-
-<br>
-
-> **Note:** 
-> - Authoring vs. Consumption 
->   - Author roles/licenses have no cost
->   - Actual cost is driven entirely by Copilot Credit Consumption
-> - Capacity Enforcement
->   - All purchased capacity is enforced monthly 
->   - Unused monthly credits do not carry over
->   - Sustained overuse can result in technical enforcement including service denial
->- For the most current licensing information, pricing, and detailed feature comparisons, refer to the official [Microsoft Copilot Studio licensing documentation](https://learn.microsoft.com/en-us/microsoft-copilot-studio/requirements-licensing).
-> <br>
-> ------
-
-### Task 2: Create a billing plan (if none is available already)
+### Task 1: Create a billing plan (if none is available already)
 
 1. Go to Power Platform Admin Center https://admin.powerplatform.microsoft.com/ and select your environment
 
@@ -129,24 +289,134 @@ Unified purchasing construct that spans Microsoft Foundry and Copilot Credits* e
 
     * **Resource group**: Select a resource group on this subscription. The Power Platform account resource—that's associated with this billing plan—is created in this resource group. If there are no resource groups in the specified subscription, you need to create one in the Azure portal before proceeding.
 
-    * **Power Platform products**: Select `Copilot Studio`and in case you haven't got Dataverse capacity available in your tenant `Dataverse` as well. `Power Automate` is optional just in case you want invoke Enterprise automations (Cloud Flows).
+    * **Power Platform products**: Select `Copilot Studio` and in case you haven't got Dataverse capacity available in your tenant `Dataverse` as well. `Power Automate` is optional just in case you want to invoke Enterprise automations (Cloud Flows).
 
-4. Click **Next**
+5. Click **Next**
 
 ![](./images/new-billing-plan-1.png)
 
-5. Choose the region where your desired environment is located, select the environment in the list, and click **Save** 
+6. Choose the region where your desired environment is located, select the environment in the list, and click **Save**
 
 ![](./images/new-billing-plan-2.png)
 
-5. Your new billing plan is created.
+7. Your new billing plan is created. You can now monitor usage and costs through Azure Cost Management.
+
+---
+
+## Exercise 3: Acquire a Copilot Studio Standalone License (P1)
+
+This exercise walks you through purchasing and assigning the Copilot Studio standalone license (Copilot Credit Capacity Pack) through the Microsoft 365 Admin Center.
+
+> **When to use P1**: Choose this model when your organization has predictable agent usage, wants fixed monthly costs, and does not require Azure AI Foundry integration under the same budget.
+
+### Prerequisites for this exercise
+
+* Microsoft 365 `Global admin` or `Billing admin` role.
+
+### Task 1: Purchase and assign licenses in Microsoft 365 Admin Center
+
+#### Step 1: Buy the tenant license (Copilot Studio)
+
+1. Go to the [Microsoft 365 Admin Center](https://admin.microsoft.com/admin/default.aspx) and sign in with your administrator account.
+
+2. On the side pane, expand the **Billing** menu, and then select **Purchase services**.
+
+3. Search for **Copilot Studio** and complete the checkout process. This is the tenant-level license that includes 25,000 Copilot Credits per pack per month.
+
+<!-- ![](./images/m365-purchase-copilot-studio.png) -->
+
+#### Step 2: Acquire user licenses (Copilot Studio User License)
+
+1. In the Microsoft 365 Admin Center, go to **Billing** > **Purchase services**.
+
+2. Scroll down to the **Add-ons** section.
+
+3. Look for **Copilot Studio User License** (free of charge).
+
+4. Select the number of licenses you need and complete the checkout process.
+
+#### Step 3: Assign user licenses
+
+1. In the Microsoft 365 Admin Center, expand the **Users** menu and select **Active users**.
+
+2. Select a user, then click **Manage product licenses**.
+
+3. On the flyout pane, select the check box next to **Copilot Studio User License**, then click **Save changes**.
+
+4. Repeat for each user who needs to create and manage agents.
+
+> **Tip:** After assigning licenses, users can sign in to [Copilot Studio](https://copilotstudio.microsoft.com) immediately.
+
+#### Step 4: Allocate capacity to environments (optional)
+
+1. Go to the [Power Platform Admin Center](https://admin.powerplatform.microsoft.com/).
+
+2. Navigate to **Resources** > **Capacity** > **Summary** tab.
+
+3. Review your available Copilot Studio credits and allocate them to specific environments as needed.
+
+> **Note:** You can combine P1 with PAYG. If capacity packs are exhausted, PAYG absorbs the overages: agents continue to work without interruption, and additional usage is billed to your Azure subscription.
+
+---
+
+## Exercise 4: Purchase a Microsoft Agent Pre-Purchase Plan (P3 Agent Factory)
+
+This exercise guides you through purchasing Agent Credit Commit Units (ACUs) via the Azure Portal Reservations experience.
+
+> **When to use P3**: Choose this model when your organization builds agents that span both Copilot Studio and Azure AI Foundry, or when you want a single unified budget for your entire AI portfolio across 32+ services.
+
+### Prerequisites for this exercise
+
+* Azure Subscription `Owner` or `Reservation purchaser` role.
+* For Enterprise Agreement (EA) subscriptions: the **Reserved Instances** policy option must be enabled by an EA administrator.
+
+### Task 1: Buy Agent Credit Commit Units in Azure Portal
+
+1. Go to the [Azure Portal](https://portal.azure.com) and navigate to the **Reservations** service.
+
+2. On the **Purchase reservations** page, select **[Microsoft Agent Prepurchase Plan](https://aka.ms/MAF-P3-Purchase)**.
+
+<!-- ![](./images/azure-p3-reservation.png) -->
+
+3. On the **Select the product you want to purchase** page:
+
+    * **Subscription**: Select the Azure subscription to be charged for the purchase.
+
+    * **Scope**: Choose how broadly the reservation discount applies:
+
+      | Scope option | Description |
+      |-------------|-------------|
+      | Single resource group | Applies to matching resources in the selected resource group only |
+      | Single subscription | Applies to matching resources in the selected subscription |
+      | Shared scope | Applies to matching resources across all eligible subscriptions in the billing context |
+      | Management group | Applies to matching resources across subscriptions in both the management group and billing scope |
+
+    * **Quantity**: Select how many Agent Credit Commit Units (ACUs) to purchase. Higher tiers unlock greater discounts.
+
+4. Choose whether to enable **auto-renewal** (enabled by default). The plan renews at the end of the one-year term.
+
+5. Review and complete the purchase.
+
+> **Important:**
+> - Cancel and exchange operations are **not** supported for Microsoft Agent Pre-Purchase Plans. All purchases are final.
+> - You cannot split or merge a Microsoft Agent Pre-Purchase Plan after purchase.
+> - ACUs are consumed automatically: no redeployment or reassignment needed.
+
+### Connecting P3 to Copilot Studio
+
+After purchasing the P3 plan, Copilot Studio usage is covered automatically when a billing policy links your Power Platform environment to the Azure subscription that holds the reservation. Follow the steps in [Exercise 2](#exercise-2-enable-pay-as-you-go-billing) to create this billing policy if you haven't already.
+
+The benefit application order ensures P3 ACUs cover Copilot Studio usage after any more specific plans (Copilot Credit Pre-Purchase) are exhausted first.
+
+---
 
 ## Next Steps
 
-After setting up your billing plan:
+After configuring your licensing:
 
 1. Start building agents in Copilot Studio
-2. Monitor your usage and costs
-3. Consider transitioning to standalone licenses if usage becomes consistent
-4. Review the [Power Platform licensing guide](https://go.microsoft.com/fwlink/?linkid=2085130) for detailed information
-5. Use the [Microsoft agent usage estimator](https://microsoft.github.io/copilot-studio-estimator/)
+2. Monitor your usage and costs through [PPAC Copilot Studio analytics](https://admin.powerplatform.microsoft.com/) and/or [Azure Cost Management](https://portal.azure.com/#blade/Microsoft_Azure_CostManagement)
+3. Use the [Microsoft agent usage estimator](https://microsoft.github.io/copilot-studio-estimator/) to forecast credit consumption
+4. If using PAYG for dev/test, consider transitioning to P1 or P3 when usage patterns stabilize
+5. Review the [Power Platform licensing guide](https://go.microsoft.com/fwlink/?linkid=2085130) for detailed information
+6. Explore [benefit application scenarios](https://learn.microsoft.com/en-us/azure/cost-management-billing/reservations/agent-pre-purchase) when combining multiple plans


### PR DESCRIPTION
Updated lab content to provide a comprehensive understanding of Copilot Studio licensing and the process for enabling Pay-as-you-go billing. Enhanced exercises and prerequisites for clarity.